### PR TITLE
Add recipient variable

### DIFF
--- a/contracts/OTPProcessorSingleUser.sol
+++ b/contracts/OTPProcessorSingleUser.sol
@@ -7,18 +7,27 @@ import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 pragma solidity >=0.7.0 <0.9.0;
 
 contract OTPProcessorSingleUser {
-    // @dev Current root OTP.
-    bytes16 public otpRoot;
-    // @dev Current root OTP counter.
-    uint16 public otpRootCounter;
-    // @dev Maximum amount of tokens that can be transferred per call.
-    uint256 public spendLimit;
     // @dev Address which can approve transfers.
     address public card;
-    // @dev Address which holds tokens.
-    address public wallet;
+
+    // @dev Current root OTP.
+    bytes16 public otpRoot;
+
+    // @dev Current root OTP counter.
+    uint16 public otpRootCounter;
+
     // @dev Address which can process transactions.
     address public processor;
+
+    // @dev Maximum amount of tokens that can be transferred per call.
+    uint256 public spendLimit;
+
+    // @dev Address which receives tokens on processed payments.
+    address public recipient;
+
+    // @dev Address which holds tokens.
+    address public wallet;
+
     // @dev ERC20 token which can be transferred by processor.
     ERC20 public token;
 
@@ -57,15 +66,17 @@ contract OTPProcessorSingleUser {
 
     constructor(
         address _card,
-        address _wallet,
         address _processor,
+        address _recipient,
         address _token,
+        address _wallet,
         uint256 _spendLimit
     ) {
         card = _card;
-        wallet = _wallet;
         processor = _processor;
+        recipient = _recipient;
         token = ERC20(_token);
+        wallet = _wallet;
         spendLimit = _spendLimit;
     }
 
@@ -106,7 +117,7 @@ contract OTPProcessorSingleUser {
         if (otp != otpRoot) revert InvalidOtp(otp);
 
         setOTPRoot(otp, counter);
-        bool success = token.transferFrom(wallet, processor, tokenAmount);
+        bool success = token.transferFrom(wallet, recipient, tokenAmount);
         if (!success) revert TransferFailed();
         emit PaymentProcessed(tokenAmount, otp, counter);
     }

--- a/test/OTPProcessorSingleUser.spec.ts
+++ b/test/OTPProcessorSingleUser.spec.ts
@@ -11,6 +11,7 @@ const otp998 = "0xee79e77077bf4f328fed0191c25088f7";
 const otp995 = "0x287f3d79476b7571b4e269e1f2bc6d3c";
 const spendLimit = ethers.utils.parseEther("100");
 const bytes16zero = "0x00000000000000000000000000000000";
+const recipient = "0x0000000000000000000000000000000000000001";
 
 describe("OTPProcessorSingleUser", function () {
   async function setup() {
@@ -35,9 +36,10 @@ describe("OTPProcessorSingleUser", function () {
     );
     const otpProcessor = await OTPProcessor.deploy(
       card.address,
-      wallet.address,
       processor.address,
+      recipient,
       token.address,
+      wallet.address,
       spendLimit
     );
 
@@ -73,6 +75,12 @@ describe("OTPProcessorSingleUser", function () {
       const { otpProcessor } = await loadFixture(setup);
 
       expect(await otpProcessor.spendLimit()).to.equal(spendLimit);
+    });
+
+    it("Should set the right recipient", async () => {
+      const { otpProcessor } = await loadFixture(setup);
+
+      expect(await otpProcessor.recipient()).to.equal(recipient);
     });
 
     it("Should not have set otpRoot and otpRootCount", async () => {
@@ -198,7 +206,7 @@ describe("OTPProcessorSingleUser", function () {
       expect(
         await otpProcessor.connect(processor).process(spendLimit, otp995, 995)
       );
-      expect(await token.balanceOf(processor.address)).to.equal(spendLimit);
+      expect(await token.balanceOf(recipient)).to.equal(spendLimit);
     });
 
     it("Should emit PaymentProcessed() event", async () => {


### PR DESCRIPTION
This PR decouples `processor` and `recipeint` so that tokens can optionally be received to a different address than the processor.